### PR TITLE
Add documentation for scripts

### DIFF
--- a/scripts/dispatcher.py
+++ b/scripts/dispatcher.py
@@ -14,6 +14,21 @@ sys.path.append(dirname(dirname(realpath(__file__))))
 from onconet.utils import parsing
 from onconet.utils.generic import md5
 
+"""Grid search dispatcher for Mirai experiments.
+
+This utility reads a JSON configuration describing multiple experiments,
+launches each job on the available GPUs and aggregates their results into a
+single CSV file. It calls ``scripts/main.py`` for the actual training or
+evaluation runs.
+
+Example
+-------
+```bash
+python scripts/dispatcher.py --experiment_config_path configs/finetune_mirai.json \
+    --result_path finetune_results.csv
+```
+"""
+
 EXPERIMENT_CRASH_MSG = "ALERT! job:[{}] has crashed! Check logfile at:[{}]"
 CONFIG_NOT_FOUND_MSG = "ALERT! {} config {} file does not exist!"
 RESULTS_PATH_APPEAR_ERR = 'results_path should not appear in config. It will be determined automatically per job'

--- a/scripts/get_dataset_stats.py
+++ b/scripts/get_dataset_stats.py
@@ -4,6 +4,18 @@ sys.path.append(dirname(dirname(realpath(__file__))))
 from onconet.utils.parsing import parse_args
 from onconet.utils.get_dataset_stats import get_dataset_stats
 
+"""Compute dataset channel statistics.
+
+Parses dataset arguments and prints the mean and standard deviation of the
+images in the dataset. This is a thin wrapper around ``onconet.utils.get_dataset_stats``.
+
+Usage
+-----
+```bash
+python scripts/get_dataset_stats.py --dataset <name> --img_dir <dir> --metadata_dir <dir>
+```
+"""
+
 
 if __name__ == "__main__":
     # REQUIRED ARGS:

--- a/scripts/main.py
+++ b/scripts/main.py
@@ -17,6 +17,18 @@ import onconet.utils.stats as stats
 import pdb
 import csv
 
+"""Main training and evaluation entry point.
+
+This script sets up datasets, models and transformers using command line
+arguments and then performs training, validation or testing.  It is the main
+interface for experimenting with Mirai models.
+
+Basic usage:
+```
+python scripts/main.py --model_name mirai_full --dataset <dataset> [flags]
+```
+"""
+
 #Constants
 DATE_FORMAT_STR = "%Y-%m-%d:%H-%M-%S"
 


### PR DESCRIPTION
## Summary
- explain how to use the main training script
- document dispatcher usage
- add documentation for dataset stats helper

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'onconet.train')*

------
https://chatgpt.com/codex/tasks/task_b_6880ba83b21c8329bea0f3944d2da7a4