### PR TITLE
Document model modules

### DIFF
--- a/onconet/models/aggregate_feat_maps.py
+++ b/onconet/models/aggregate_feat_maps.py
@@ -1,3 +1,20 @@
+"""Aggregate patch-level feature maps into image-level predictions.
+
+This module contains :class:`CustomBlock_Agg`, which attaches additional
+ResNet blocks to a patch model and combines their outputs. The model can
+either recompute features or operate on precomputed hidden tensors when
+``args.use_precomputed_hiddens`` is set.
+
+Key constructor arguments
+-------------------------
+patch_snapshot : str
+    Path to a saved patch model to load.
+block_layout : list of ``int``
+    Number of blocks for each added ResNet stage.
+use_precomputed_hiddens : bool
+    If ``True`` skip the patch network and expect hidden tensors as input.
+"""
+
 import torch
 import torch.nn as nn
 import torch.nn.functional as F
@@ -17,8 +34,10 @@ class CustomBlock_Agg(nn.Module):
 
         self.args = args
         if not args.use_precomputed_hiddens:
+            # Load the patch-level feature extractor from a snapshot
             self.feat_extractor = load_model(args.patch_snapshot, args, False)
         agg_layers = get_layers(args.block_layout)
+        # ResNet stack used to aggregate the extracted feature maps
         self._model = ResNet(agg_layers, args)
 
 
@@ -30,12 +49,15 @@ class CustomBlock_Agg(nn.Module):
         '''
         x = x.data
         if not self.args.use_precomputed_hiddens:
+            # Extract patch-level feature maps before aggregation
             _, _, x = self.feat_extractor(x, risk_factors)
         x = x.data
+        # Run the aggregation ResNet on the feature maps
         logit, hidden, x = self._model(x, risk_factors)
         return logit, hidden, x
 
     def cuda(self, device=None):
+        # Move both the patch feature extractor and aggregation model to GPU
         self.feat_extractor = self.feat_extractor.cuda(device)
         self._model = self._model.cuda(device)
         return self

--- a/onconet/models/aggregator.py
+++ b/onconet/models/aggregator.py
@@ -1,3 +1,19 @@
+"""Fully-connected aggregator on top of a pretrained patch model.
+
+The :class:`Aggregator` loads a patch-level network from ``args.patch_snapshot``
+and attaches a small MLP that produces image-level logits. It optionally
+handles multi-image inputs by flattening all features before the MLP.
+
+Key constructor arguments
+-------------------------
+patch_snapshot : str
+    Path to the saved patch network weights.
+num_classes : int
+    Number of classes predicted by the final linear layer.
+num_images : int
+    When ``args.multi_image`` is set, denotes images aggregated per sample.
+"""
+
 import torch
 import torch.nn as nn
 import torch.nn.functional as F
@@ -12,22 +28,31 @@ class Aggregator(nn.Module):
             Given some a patch model, add add some FC layers and a shortcut to make whole image prediction
        '''
         super(Aggregator, self).__init__()
+        # Load the patch-level model that produced the features
         print('\nLoading patch model from [%s]...' % args.patch_snapshot)
         try:
             patch_model = torch.load( args.patch_snapshot).cpu()
             self.patch_model = strip_model( patch_model )
         except Exception as e:
-            raise Exception("Couldn't load patch model at {}. Error: {}".format(args.patch_snapshot, e));
+            raise Exception(
+                "Couldn't load patch model at {}. Error: {}".format(
+                    args.patch_snapshot, e
+                )
+            )
 
         args.wrap_model = False
         self.args = args
 
         if args.multi_image:
-            img_size = ( args.num_images, *args.img_size)
+            # Adjust input size when multiple images are provided per sample
+            img_size = (args.num_images, *args.img_size)
 
-        args.hidden_dim = get_output_size(self.patch_model , img_size, args.num_chan, args.cuda)
-        fc1_dim = max(2056, args.hidden_dim/8)
-        fc2_dim = max(1024, args.hidden_dim/16)
+        # Determine feature dimensionality coming from the patch model
+        args.hidden_dim = get_output_size(
+            self.patch_model, img_size, args.num_chan, args.cuda
+        )
+        fc1_dim = max(2056, args.hidden_dim / 8)
+        fc2_dim = max(1024, args.hidden_dim / 16)
 
         self.fc1 = nn.Linear( args.hidden_dim, fc1_dim)
         self.fc2 = nn.Linear( fc1_dim, fc2_dim)
@@ -39,8 +64,7 @@ class Aggregator(nn.Module):
             param x: a batch of image tensors
             returns hidden: last hidden layer of model (as if wrapper wasn't applied)
         '''
-
-        ## We assume path model is wrapped in a modelWrapper from a prev run
+        # We assume the patch model is wrapped in a ModelWrapper from a previous run
         patch_hidden  = self.patch_model(x)
         patch_hidden = patch_hidden.view(patch_hidden.size()[0], -1)
         patch_hidden = F.relu( self.fc1( patch_hidden) )

--- a/onconet/models/cumulative_probability_layer.py
+++ b/onconet/models/cumulative_probability_layer.py
@@ -1,3 +1,21 @@
+"""Module implementing a cumulative probability head for survival models.
+
+The :class:`Cumulative_Probability_Layer` predicts a hazard for each
+follow-up period and optionally accumulates the hazards into cumulative
+probabilities. This is used to transform extracted image features into a
+time-dependent risk estimate.
+
+Key constructor arguments
+-------------------------
+num_features : int
+    Dimensionality of the input feature tensor.
+max_followup : int
+    Number of discrete time steps for which hazards are predicted.
+make_probs_indep : bool
+    When ``True`` the layer outputs independent hazard predictions without
+    the cumulative sum.
+"""
+
 import torch
 import torch.nn as nn
 import pdb
@@ -8,26 +26,32 @@ class Cumulative_Probability_Layer(nn.Module):
     def __init__(self, num_features, args, max_followup):
         super(Cumulative_Probability_Layer, self).__init__()
         self.args = args
-        self.hazard_fc = nn.Linear(num_features,  max_followup)
+        # Linear layer predicting hazards for each follow-up period
+        self.hazard_fc = nn.Linear(num_features, max_followup)
+        # Bias term representing baseline hazard
         self.base_hazard_fc = nn.Linear(num_features, 1)
         self.relu = nn.ReLU(inplace=True)
+        # Mask used to compute cumulative sums via matrix multiplication
         mask = torch.ones([max_followup, max_followup])
         mask = torch.tril(mask, diagonal=0)
         mask = torch.nn.Parameter(torch.t(mask), requires_grad=False)
         self.register_parameter('upper_triagular_mask', mask)
 
     def hazards(self, x):
+        # Apply the linear layer and enforce positivity via ReLU
         raw_hazard = self.hazard_fc(x)
         pos_hazard = self.relu(raw_hazard)
         return pos_hazard
 
     def forward(self, x):
         if self.args.make_probs_indep:
+            # In certain experiments hazards are returned directly
             return self.hazards(x)
-#        hazards = self.hazard_fc(x)
+
         hazards = self.hazards(x)
-        B, T = hazards.size() #hazards is (B, T)
-        expanded_hazards = hazards.unsqueeze(-1).expand(B, T, T) #expanded_hazards is (B,T, T)
-        masked_hazards = expanded_hazards * self.upper_triagular_mask # masked_hazards now (B,T, T)
+        B, T = hazards.size()  # hazards is (B, T)
+        # Expand hazards so each time step accumulates past hazards
+        expanded_hazards = hazards.unsqueeze(-1).expand(B, T, T)
+        masked_hazards = expanded_hazards * self.upper_triagular_mask
         cum_prob = torch.sum(masked_hazards, dim=1) + self.base_hazard_fc(x)
         return cum_prob

--- a/onconet/models/custom_resnet.py
+++ b/onconet/models/custom_resnet.py
@@ -1,3 +1,19 @@
+"""Custom ResNet backbone used in the Mirai architecture.
+
+This module exposes :class:`CustomResnet`, a thin wrapper around
+``ResNet`` that allows the block configuration and pretrained weights
+to be specified at runtime.
+
+Parameters passed through ``args``
+-------------------------------
+block_layout: list of ``int``
+    Defines the number of blocks per stage of the network.
+pretrained_imagenet_model_name: str
+    Name of the torchvision ResNet variant to load weights from.
+pretrained_on_imagenet: bool
+    If ``True`` the backbone is initialised with ImageNet weights.
+"""
+
 from torch import nn
 
 from onconet.models.factory import RegisterModel, load_pretrained_weights, get_layers
@@ -8,16 +24,22 @@ from onconet.models.resnet_base import ResNet
 class CustomResnet(nn.Module):
     def __init__(self, args):
         super(CustomResnet, self).__init__()
+        # Build the underlying ResNet with the user-provided block layout
         layers = get_layers(args.block_layout)
         self._model = ResNet(layers, args)
         model_name = args.pretrained_imagenet_model_name
         if args.pretrained_on_imagenet:
-            load_pretrained_weights(self._model,
-                                    load_pretrained_model(model_name))
+            # Optionally initialise with ImageNet weights
+            load_pretrained_weights(
+                self._model, load_pretrained_model(model_name)
+            )
 
     def forward(self, x, risk_factors=None, batch=None):
+        # Delegate to the underlying ResNet. ``batch`` is unused but kept for
+        # API compatibility with other models in this package.
         return self._model(x, risk_factors=risk_factors, batch=None)
 
     def cuda(self, device=None):
+        # Ensure the wrapped model resides on the correct device
         self._model = self._model.cuda(device)
         return self


### PR DESCRIPTION
## Summary
- document `CustomResnet` model wrapper
- explain how feature map aggregation works
- clarify aggregator MLP model
- document cumulative probability head

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'onconet.train')*

------
https://chatgpt.com/codex/tasks/task_b_6880ba7ef87483299e2625ed62e66ad3